### PR TITLE
Add version attribute to existing benchmarks

### DIFF
--- a/xradio/benchmarks/measurement_set.py
+++ b/xradio/benchmarks/measurement_set.py
@@ -16,11 +16,12 @@ from xradio.testing.measurement_set.io import download_measurement_set
 class TestLoadProcessingSet:
     """
     Tests for load_processing_set using real data
-    Adapted from:
+    Originally adapted from:
     https://github.com/casangi/xradio/blob/main/tests/unit/measurement_set/test_load_processing_set.py
     at commit:
     b1618b0fa08a3e657dff8905eb93d298717b7ae5
     """
+    version = "xradio 1.0.2"
 
     MeasurementSet = "Antennae_North.cal.lsrk.split.ms"
     processing_set = "test_processing_set.ps.zarr"
@@ -29,7 +30,7 @@ class TestLoadProcessingSet:
         # perform the expensive operations once (per env, per commit), see
         # https://asv.readthedocs.io/en/stable/writing_benchmarks.html#setup-and-teardown-functions
 
-        # adapted from https://github.com/casangi/xradio/blob/main/tests/unit/measurement_set/conftest.py
+        # originally adapted from https://github.com/casangi/xradio/blob/main/tests/unit/measurement_set/conftest.py
 
         ms_path = download_measurement_set(self.MeasurementSet)
 
@@ -116,12 +117,13 @@ class TestLoadProcessingSet:
 class TestProcessingSetXdtWithData:
     """
     Benchmarks for ProcessingSetXdt using real data
-    Adapted from:
+    Originally adapted from:
     https://github.com/casangi/xradio/blob/main/tests/unit/measurement_set/test_processing_set_xdt.py
     TestProcessingSetXdtWithData class
     at commit:
     b1618b0fa08a3e657dff8905eb93d298717b7ae5
     """
+    version = "xradio 1.0.2"
 
     MeasurementSet = "Antennae_North.cal.lsrk.split.ms"
     processing_set = "test_processing_set_xdt.ps.zarr"
@@ -130,7 +132,7 @@ class TestProcessingSetXdtWithData:
         # perform the expensive operations once (per env, per commit), see
         # https://asv.readthedocs.io/en/stable/writing_benchmarks.html#setup-and-teardown-functions
 
-        # adapted from https://github.com/casangi/xradio/blob/main/tests/_utils/conftest.py
+        # originally adapted from https://github.com/casangi/xradio/blob/main/tests/_utils/conftest.py
 
         ms_path = download_measurement_set(self.MeasurementSet)
 
@@ -198,12 +200,13 @@ class TestProcessingSetXdtWithData:
 class TestProcessingSetXdtWithEphemerisData:
     """
     Benchmarks for ProcessingSetXdt using real ephemeris data
-    Adapted from:
+    Originally adapted from:
     https://github.com/casangi/xradio/blob/main/tests/unit/measurement_set/test_processing_set_xdt.py
     TestProcessingSetXdtWithEphemerisData class
     at commit:
     b1618b0fa08a3e657dff8905eb93d298717b7ae5
     """
+    version = "xradio 1.0.2"
 
     MeasurementSet = "ALMA_uid___A002_X1003af4_X75a3.split.avg.ms"
     processing_set = "test_processing_set_xdt_ephemeris.ps.zarr"
@@ -212,7 +215,7 @@ class TestProcessingSetXdtWithEphemerisData:
         # perform the expensive operations once (per env, per commit), see
         # https://asv.readthedocs.io/en/stable/writing_benchmarks.html#setup-and-teardown-functions
 
-        # adapted from https://github.com/casangi/xradio/blob/main/tests/_utils/conftest.py
+        # originally adapted from https://github.com/casangi/xradio/blob/main/tests/_utils/conftest.py
 
         ms_path = download_measurement_set(self.MeasurementSet)
 
@@ -254,12 +257,12 @@ class TestProcessingSetXdtWithEphemerisData:
 class TestMeasurementSetXdtWithData:
     """
     Benchmarks for MeasurementSetXdt using real data
-    Adapted from:
+    Originally adapted from:
     https://github.com/casangi/xradio/blob/main/tests/unit/measurement_set/test_measurement_set_xdt.py
     at commit:
     b1618b0fa08a3e657dff8905eb93d298717b7ae5
-
     """
+    version = "xradio 1.0.2"
 
     def setup_cache(self):
         ms_path, _ = gen_minimal_ms()


### PR DESCRIPTION
Any string would work to override the hash of the setup and test code, but I chose one corresponding to ~ the release of xradio where we might expect tests in their current state to remain stable. That could be changed if desired, but of course it would be better to pick something _before_ trying to keep a stable result history.

Local testing of the changes on a linux machine with `asv run "--merges v1.0.2..main" --parallel --interleave-rounds --skip-existing` successfully builds environments for the following commits:
```
# all tests fail due to setup cache error -- seems expected due to breaking API changes
47a4adbf <main~5>
0e7406a0 <pull/529/head~1>
5d8a8055 <v1.1.0~1>

# some tests fail, most of them pass
29a3679f <main>
23975044 <main~3>

# all tests pass
12d9cddd <v1.1.5-alpha>
cee1df0d <v1.1.5-alpha~1>
4e8860a6 <v1.1.5-alpha~2>
05c22add <v1.1.5-alpha~3>
```